### PR TITLE
 Add support for portage package manager

### DIFF
--- a/flowetch
+++ b/flowetch
@@ -16,6 +16,9 @@ then
 elif  command -v dpkg >/dev/null
 then
   pkg="$(dpkg -l | wc -l)"
+elif  command -v emerge >/dev/null
+then
+  pkg="$(cd /var/db/pkg/ && ls -d */* | wc -l)"
 elif  command -v xbps-query >/dev/null
 then
     pkg="$(xbps-query -l | wc -l)"


### PR DESCRIPTION
Use the package "database" instead of equery because not everyone have
gentoolkit installed